### PR TITLE
docs: rebranding rabbot to foo-foo-mq

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ spec/
 plato/
 coverage/
 .vagrant/
+.idea

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 ## Contributors
 
-These folks have all made significant or ongoing contributions to the original [rabbot](https://github.com/arobson/rabbot) implementation this project is based on:
+These folks have all made significant contributions to the original [rabbot](https://github.com/arobson/rabbot) implementation this project is based on:
 
  * [Alex Robson](http://github.com/arobson)
  * [Derick Bailey](http://derickbailey.com/)

--- a/HOW_TO_CONTRIBUTE.md
+++ b/HOW_TO_CONTRIBUTE.md
@@ -1,24 +1,24 @@
 ## Contributor Guide
 
-This is intended to help you make a contribution to Rabbot that is likely to land. It includes basic instructions for getting the project running locally, ensuring CI will pass and reducing the chances that you will be asked to make changes by a maintainer or have the PR closed without comment for failing simple criteria.
+This is intended to help you make a contribution to Foo-foo-mq that is likely to land. It includes basic instructions for getting the project running locally, ensuring CI will pass and reducing the chances that you will be asked to make changes by a maintainer or have the PR closed without comment for failing simple criteria.
 
 A lot of the criteria here is to make it much easier for maintainers to accept or reject PRs without having to do additional work. It's also intended to save people time and effort in advance if they're not interested in meeting the criteria required to submit an acceptable PR.
 
 ### Setup
 
-The current dev environment for Rabbot is:
+The current dev environment for Foo-foo-mq is:
 
  * Node 6 or 8
  * Docker (to run RabbitMQ in a container for integration tests)
 
-It is recommended that you not use a RabbitMQ server running outside Docker as failing Rabbot integration tests may make a mess that you'll be stuck cleaning up :cry: It is much easier to just remove the Docker container and start over.
+It is recommended that you not use a RabbitMQ server running outside Docker as failing foo-foo-mq integration tests may make a mess that you'll be stuck cleaning up :cry: It is much easier to just remove the Docker container and start over.
 
 #### Included Docker Container
 
 The repo includes a Dockerfile as well as npm commands to build, start and stop and remove the container:
 
- * `npm run build-image` - build Docker image (includes plugins needed for rabbot)
- * `npm run create-container` - creates a container named `rabbot` for tests
+ * `npm run build-image` - build Docker image (includes plugins needed for foo-foo-mq)
+ * `npm run create-container` - creates a container named `foofoomq` for tests
  * `npm run start-container` - starts the container if it was stopped
  * `npm run stop-container` - stops the container only
  * `npm run remove-container` - stops and removes the container entirely
@@ -56,7 +56,7 @@ New features without both behavior and integration tests will not be accepted. T
 
 The expectation is that if you are changing a behavior that you include a test to demonstrate the correction addresses the behavior you are changing.
 
-This is very important as Rabbot has changed drastically over the years and without good tests in place, regressions are likely to creep in. Please help ensure that your fixes stay fixed :smile:
+This is very important as Foo-foo-mq has changed drastically over the years and without good tests in place, regressions are likely to creep in. Please help ensure that your fixes stay fixed :smile:
 
 ### Style & Linting
 
@@ -64,4 +64,4 @@ Running `npm test`, `npm run lint` and `npm run lint-fix` are all ways to check/
 
 PRs that break or change style rules will be ignored and after a time, if not repaired, they will be rejected.
 
-Rabbot now uses semistandard (standard + semicolons). This is less about it being a perfect format vs it being a low maintenance way to have tooling and automation around ensuring a *consistent* style stay in place across all PRs.
+Foo-foo-mq now uses semistandard (standard + semicolons). This is less about it being a perfect format vs it being a low maintenance way to have tooling and automation around ensuring a *consistent* style stay in place across all PRs.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rabbot
+# foo-foo-mq
 
 [![Build Status][travis-image]][travis-url]
 [![Coverage Status][coveralls-image]][coveralls-url]
@@ -36,7 +36,7 @@ This is a very opinionated abstraction over amqplib to help simplify the impleme
  * [Topology Setup](https://github.com/zlintz/foo-foo-mq/blob/master/docs/topology.md) - topology configuration
  * [Publishing Guide](https://github.com/zlintz/foo-foo-mq/blob/master/docs/publishing.md) - publishing and requesting
  * [Receiving Guide](https://github.com/zlintz/foo-foo-mq/blob/master/docs/receiving.md) - subscribing and handling of messages
- * [Logging](https://github.com/zlintz/foo-foo-mq/blob/master/docs/logging.md) - how rabbot logs
+ * [Logging](https://github.com/zlintz/foo-foo-mq/blob/master/docs/logging.md) - how foo-foo-mq logs
 
 ## Other Documents
 
@@ -76,7 +76,7 @@ rabbit.configure({
     name: 'default',
     user: 'guest',
     pass: 'guest',
-    host: 'my-rabbot-server',
+    host: 'my-rabbitmq-server',
     port: 5672,
     vhost: '%2f',
     replyQueue: 'customReplyQueue'
@@ -106,7 +106,7 @@ rabbit.publish('ex.1', { type: 'MyMessage', body: 'hello!' });
 
 
 setTimeout(() => {
-  rabbot.shutdown(true)
+  rabbit.shutdown(true)
 },5000);
 ```
 
@@ -118,7 +118,7 @@ setTimeout(() => {
 [travis-url]: https://travis-ci.org/zlintz/foo-foo-mq
 [coveralls-url]: https://coveralls.io/github/zlintz/foo-foo-mq?branch=master
 [coveralls-image]: https://coveralls.io/repos/github/zlintz/foo-foo-mq/badge.svg?branch=master
-[version-image]: https://img.shields.io/npm/v/rabbot.svg?style=flat
+[version-image]: https://img.shields.io/npm/v/foo-foo-mq.svg?style=flat
 [version-url]: https://www.npmjs.com/package/foo-foo-mq
 [downloads-image]: https://img.shields.io/npm/dm/foo-foo-mq.svg?style=flat
 [downloads-url]: https://www.npmjs.com/package/foo-foo-mq

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -29,7 +29,7 @@ Options is a hash that can contain the following:
 | **publishTimeout** | the default timeout in milliseconds for a publish call. | |
 | **replyTimeout** | the default timeout in milliseconds to wait for a reply. | |
 | **failAfter** | limits how long foofoomq will attempt to connect (in seconds). | `60` |
-| **retryLimit** | limits how many consecutive failed attempts rabbot will make. | `3` |
+| **retryLimit** | limits how many consecutive failed attempts foofoomq will make. | `3` |
 | **waitMin** | how long to delay (in ms) before initial reconnect. | `0` |
 | **waitMax** | maximum delay (in ms) between retry attempts. | `5000` |
 | **waitIncrement** | how much to increase the delay (in ms) with each retry attempt. | `100` |
@@ -62,11 +62,11 @@ rabbit.addConnection( {
 
 ## `failAfter` and `retryLimit`
 
-rabbot will stop trying to connect/re-connect if either of these thresholds is reached (whichever comes first).
+foo-foo-mq will stop trying to connect/re-connect if either of these thresholds is reached (whichever comes first).
 
 ## `clientProperties`
 
-The client properties are shown in the RabbitMQ management console under a specific connection. This is an example of the default client properties provided by rabbot:
+The client properties are shown in the RabbitMQ management console under a specific connection. This is an example of the default client properties provided by foo-foo-mq:
 
 ```json
 {
@@ -80,15 +80,15 @@ By setting `clientProperties` you extend that list with your custom properties. 
 
 ## Cluster Support
 
-rabbot provides the ability to define multiple nodes per connections by supplying either a comma delimited list or array of server IPs or names to the `host` property. You can also specify multuple ports in the same way but make certain that either you provide a single port for all servers or that the number of ports matches the number and order of servers.
+foo-foo-mq provides the ability to define multiple nodes per connections by supplying either a comma delimited list or array of server IPs or names to the `host` property. You can also specify multiple ports in the same way but make certain that either you provide a single port for all servers or that the number of ports matches the number and order of servers.
 
 ## Shutting Down
 
-Both exchanges and queues have asynchronous processes that work behind the scenes processing publish confirms and batching message acknowledgements. To shutdown things in a clean manner, rabbot provides a `shutdown` method that returns a promise which will resolve once all outstanding confirmations and batching have completed and the connection is closed.
+Both exchanges and queues have asynchronous processes that work behind the scenes processing publish confirms and batching message acknowledgements. To shutdown things in a clean manner, foo-foo-mq provides a `shutdown` method that returns a promise which will resolve once all outstanding confirmations and batching have completed and the connection is closed.
 
 ## Events
 
-rabbot emits both generic and specific connectivity events that you can bind to in order to handle various states:
+foo-foo-mq emits both generic and specific connectivity events that you can bind to in order to handle various states:
 
 * Any Connection
  * `connected` - connection to a broker succeeds
@@ -103,7 +103,7 @@ rabbot emits both generic and specific connectivity events that you can bind to 
 
 The connection object is passed to the event handler for each event. Use the `name` property of the connection object to determine which connection the generic events fired for.
 
-> !IMPORTANT! - rabbot handles connectivity for you, mucking about with the connection directly isn't supported, *just don't*.
+> !IMPORTANT! - foo-foo-mq handles connectivity for you, mucking about with the connection directly isn't supported, *just don't*.
 
 ## Managing Connections - Retry, Close and Shutdown
 
@@ -111,27 +111,27 @@ These methods should not see regular use inside of a typical long-running servic
 
 Realize that this is rare and that it's ok for services to fail and restart by a service management layer or cluster orchestration (Docker, especially in the context of something like Kubernetes).
 
-During intentional connection close or shutdown, rabbot will attempt to resolve all outstanding publishes and recieved messages (ack/nack/reject) before closing the channels and connection intentionally. If you would like to defer certain actions until after everything has been safely resolved, then use the promise returned from either close call.
+During intentional connection close or shutdown, foo-foo-mq will attempt to resolve all outstanding publishes and received messages (ack/nack/reject) before closing the channels and connection intentionally. If you would like to defer certain actions until after everything has been safely resolved, then use the promise returned from either close call.
 
-> !!! CAUTION !!! - passing reset is dangerous. All topology associated with the connection will be removed locally meaning rabbot will _not_ be able to re-establish it all should you decide to reconnect. It's really there to support integration teardown.
+> !!! CAUTION !!! - passing reset is dangerous. All topology associated with the connection will be removed locally meaning foo-foo-mq will _not_ be able to re-establish it all should you decide to reconnect. It's really there to support integration teardown.
 
-### `rabbot.close( [connectionName], [reset] )`
+### `rabbit.close( [connectionName], [reset] )`
 
 Closes the connection, optionally resetting all previously defined topology for the connection. The `connectionName` is `default` if one is not provided.
 
-### `rabbot.closeAll( [reset] )`
+### `rabbit.closeAll( [reset] )`
 
 Closes __all__ connections, optionally resetting the topology for all of them.
 
-### `rabbot.retry()`
+### `rabbit.retry()`
 
-After an `unhandled` event is raised by rabbot, not further attempts to connect will be made unless `retry` is called.
+After an `unhandled` event is raised by foo-foo-mq, not further attempts to connect will be made unless `retry` is called.
 
 It's worth noting that you should be pairing this with monitoring and alerting on your Broker so that you aren't relying on indefinite retry. Your goal should not be services that never restart. Your goal should be building systems resilient to failures (by allowing them to crash and restart gracefully).
 
 ```js
 // How to create a zombie
-var rabbit = require( "rabbot" );
+var rabbit = require( "foo-foo-mq" );
 
 rabbit.on( "unreachable", function() {
   rabbit.retry();
@@ -139,13 +139,13 @@ rabbit.on( "unreachable", function() {
 
 ```
 
-### `rabbot.shutdown()`
+### `rabbit.shutdown()`
 
-Once a connection is established, rabbot will keep the process running unless you call `shutdown`. This is because most services shouldn't automatically shutdown at the first accidental disconnection`. Shutdown attempts to provide the same guarantees as close - only allowing the process to exit after publishing and resolving received messages.
+Once a connection is established, foo-foo-mq will keep the process running unless you call `shutdown`. This is because most services shouldn't automatically shutdown at the first accidental disconnection`. Shutdown attempts to provide the same guarantees as close - only allowing the process to exit after publishing and resolving received messages.
 
 ## AMQPS, SSL/TLS Support
 
-Providing the following configuration options setting the related environment varibles will cause rabbot to attempt connecting via AMQPS. For more details about which settings perform what role, refer to the amqplib's page on [SSL](http://www.squaremobius.net/amqp.node/doc/ssl.html).
+Providing the following configuration options setting the related environment variables will cause foo-foo-mq to attempt connecting via AMQPS. For more details about which settings perform what role, refer to the amqplib's page on [SSL](http://www.squaremobius.net/amqp.node/doc/ssl.html).
 
 ```javascript
   connection: {     // sample connection hash
@@ -161,9 +161,9 @@ Providing the following configuration options setting the related environment va
 
 ### Publishing
 
-For exchanges in confirm mode (the default), rabbot will attempt to retain messages you publish during the attempt to connect which it will publish if a connection can be successfully established. It is important to handle rejection of the publish. Only resolved publishes are guaranteed to have been delivered to the broker.
+For exchanges in confirm mode (the default), foo-foo-mq will attempt to retain messages you publish during the attempt to connect which it will publish if a connection can be successfully established. It is important to handle rejection of the publish. Only resolved publishes are guaranteed to have been delivered to the broker.
 
-Rabbot limits the number of messages it will retain for each exchange to 100 by default. After the limit is reached, all further publishes will be rejected automatically. This limit was put in place to prevent unbounded memory consumption.
+Foo-foo-mq limits the number of messages it will retain for each exchange to 100 by default. After the limit is reached, all further publishes will be rejected automatically. This limit was put in place to prevent unbounded memory consumption.
 
 ### Subscribing
 
@@ -171,6 +171,6 @@ The default batch acknowledgement behavior is the default mode for all queues un
 
 > Warning: batching, while complicated, pays off in terms of throughput and decreased broker load.
 
-If a connection is lost before all the batched resolutions (acks, nacks, rejections) have completed, the unresolved messages will be returned to their respective queues and be delivered to the next consumer. _This is an unavoidable aspect of "at least once delivery"; rabbot's default behavior._
+If a connection is lost before all the batched resolutions (acks, nacks, rejections) have completed, the unresolved messages will be returned to their respective queues and be delivered to the next consumer. _This is an unavoidable aspect of "at least once delivery"; foo-foo-mq's default behavior._
 
 If this is undesirable, your options are to turn of acknowledgements (which puts you in "at most once delivery") or turn off batching (which will incur a significant perf penalty in terms of service throughput and broker load).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -2,7 +2,7 @@
 
 As of v2, logging uses [bole](https://github.com/rvagg/bole) because it defaults to machine parsable logs, minimalistic and easy to write stream adapters for.
 
-A DEBUG adapter that works just like before is already included in rabbot, so you can still prefix the service with `DEBUG=rabbot.*` to get rabbot specific output.
+A DEBUG adapter that works just like before is already included in foo-foo-mq, so you can still prefix the service with `DEBUG=rabbot.*` to get foo-foo-mq specific output.
 
 > Note: `rabbot.queue.*` and `rabbot.exchange.*` are high volume namespaces since that is where all published and subscribed messages get reported.
 
@@ -11,10 +11,10 @@ A DEBUG adapter that works just like before is already included in rabbot, so yo
 A log call is now exposed directly to make it easier to attach streams to the bole instance:
 
 ```js
-const rabbot = require( "rabbot" );
+const rabbit = require( "foo-foo-mq" );
 
 // works like bole's output call
-rabbot.log( [
+rabbit.log( [
   { level: "info", stream: process.stdout },
   { level: "debug", stream: fs.createWriteStream( "./debug.log" ), objectMode: true }
 ] );

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,16 +1,16 @@
 # Publishing
 
-In confirm mode (the default for exchanges), the publish call returns a promise that is only resolved once the broker has confirmed the publish (see [Publisher Acknowledgments](https://www.rabbitmq.com/confirms.html) for more details). If a configured timeout is reached, or in the rare event that the broker rejects the message, the promise will be rejected. More commonly, the connection to the broker could be lost before the message is confirmed and you end up with a message in "limbo". rabbot keeps a list of unconfirmed messages that have been published _in memory only_. Once a connection is available and the topology is in place, rabbot will send messages in the order of the publish calls. In the event of a disconnection or unreachable broker, all publish promises that have not been resolved are rejected.
+In confirm mode (the default for exchanges), the publish call returns a promise that is only resolved once the broker has confirmed the publish (see [Publisher Acknowledgments](https://www.rabbitmq.com/confirms.html) for more details). If a configured timeout is reached, or in the rare event that the broker rejects the message, the promise will be rejected. More commonly, the connection to the broker could be lost before the message is confirmed and you end up with a message in "limbo". foo-foo-mq keeps a list of unconfirmed messages that have been published _in memory only_. Once a connection is available and the topology is in place, foo-foo-mq will send messages in the order of the publish calls. In the event of a disconnection or unreachable broker, all publish promises that have not been resolved are rejected.
 
-Publish timeouts can be set per message, per exchange or per connection. The most specific value overrides any set at a higher level. There are no default timeouts set at any level. The timer is started as soon as publish is called and only cancelled once rabbot is able to make the publish call on the actual exchange's channel. The timeout is cancelled once publish is called and will not result in a rejected promise due to time spent waiting on a confirmation.
+Publish timeouts can be set per message, per exchange or per connection. The most specific value overrides any set at a higher level. There are no default timeouts set at any level. The timer is started as soon as publish is called and only cancelled once foo-foo-mq is able to make the publish call on the actual exchange's channel. The timeout is cancelled once publish is called and will not result in a rejected promise due to time spent waiting on a confirmation.
 
-> Caution: rabbot does _not_ limit the growth of pending published messages. If a service cannot connect to Rabbit due to misconfiguration or the broker being down, publishing lots of messages can lead to out-of-memory errors. It is the consuming services responsibility to handle these kinds of scenarios.
+> Caution: foo-foo-mq does _not_ limit the growth of pending published messages. If a service cannot connect to Rabbit due to misconfiguration or the broker being down, publishing lots of messages can lead to out-of-memory errors. It is the consuming services responsibility to handle these kinds of scenarios.
 
 Confirm mode is not without an overhead cost. This can be turned off, per exchange, by setting `noConfirm: true`. Confirmation results in increased memory overhead on the client and broker. When off, the promise will _always_ resolve when the connection and exchange are available.
 
 #### Serializers
 
-rabbot associates serialization techniques for messages with mimeTypes which can now be set when publishing a message. Out of the box, it really only supports 3 types of serialization:
+foo-foo-mq associates serialization techniques for messages with mimeTypes which can now be set when publishing a message. Out of the box, it really only supports 3 types of serialization:
 
  * `"text/plain"`
  * `"application/json"`
@@ -18,7 +18,7 @@ rabbot associates serialization techniques for messages with mimeTypes which can
 
 You can register your own serializers using `addSerializer` but make sure to do so on both the sending and receiving side of the message.
 
-## `rabbot.publish( exchangeName, options, [connectionName] )`
+## `rabbit.publish( exchangeName, options, [connectionName] )`
 
 Things to remember when publishing a message:
 
@@ -56,9 +56,9 @@ rabbit.publish( "exchange.name",
 );
 ```
 
-## `rabbot.request( exchangeName, options, [connectionName] )`
+## `rabbit.request( exchangeName, options, [connectionName] )`
 
-This works just like a publish except that the promise returned provides the response (or responses) from the other side. A `replyTimeout` is available in the options that controls how long rabbot will wait for a reply before removing the subscription for the request to prevent memory leaks.
+This works just like a publish except that the promise returned provides the response (or responses) from the other side. A `replyTimeout` is available in the options that controls how long foo-foo-mq will wait for a reply before removing the subscription for the request to prevent memory leaks.
 
 > Note: the default replyTimeout will be double the publish timeout or 1 second if no publish timeout was ever specified.
 
@@ -125,11 +125,11 @@ rabbit.handle('request', (req) => {
 
 In scatter-gather: the recipients don't know how many of them there are and don't have to be aware that they are participating in scatter-gather/race-conditions.
 
-They just reply. The limit is applied on the requesting side by setting a `expects` property on the outgoing message to let rabbot how many messages to collect before stopping and considering the request satisfied.
+They just reply. The limit is applied on the requesting side by setting a `expects` property on the outgoing message to let foo-foo-mq how many messages to collect before stopping and considering the request satisfied.
 
 Normally this is done with mutliple responders on the other side of a topic or fanout exchange.
 
-> !IMPORTANT! - messages beyond the limit are treated as unhandled. You'll need to have an unhandled message strategy in place or at least understand how rabbot deals with them by default.
+> !IMPORTANT! - messages beyond the limit are treated as unhandled. You'll need to have an unhandled message strategy in place or at least understand how foo-foo-mq deals with them by default.
 
 ```js
 // request side
@@ -154,7 +154,7 @@ rabbit.handle('request', (req) => {
 });
 ```
 
-## `rabbot.bulkPublish( set, [connectionName] )`
+## `rabbit.bulkPublish( set, [connectionName] )`
 
 This creates a promise for a set of publishes to one or more exchanges on the same connection.
 
@@ -169,7 +169,7 @@ Each key is the name of the exchange to publish to and the value is an array of 
 The exchanges are processed serially, so this option will not work if you want finer control over sending messages to multiple exchanges in interleaved order.
 
 ```js
-rabbot.publish({
+rabbit.publish({
   'exchange-1': [
     { type: 'one', body: '1' },
     { type: 'one', body: '2' }
@@ -189,7 +189,7 @@ rabbot.publish({
 Each element in the array follows the format of `publish`'s option but requires the `exchange` property to control which exchange to publish each message to.
 
 ```js
-rabbot.publish([
+rabbit.publish([
   { type: 'one', body: '1', exchange: 'exchange-1' },
   { type: 'one', body: '2', exchange: 'exchange-1' },
   { type: 'two', body: '1', exchange: 'exchange-2' },

--- a/docs/receiving.md
+++ b/docs/receiving.md
@@ -2,8 +2,8 @@
 
 Covering message handling and subscriptions.
 
-## `rabbot.handle( options, handler )`
-## `rabbot.handle( typeName, handler, [queueName], [context] )`
+## `rabbit.handle( options, handler )`
+## `rabbit.handle( typeName, handler, [queueName], [context] )`
 
 > Notes:
 > * Handle calls should happen __before__ starting subscriptions.
@@ -51,7 +51,7 @@ handler.remove();
 
 ### Automatically Nack On Error
 
-This example shows how to have rabbot wrap all handlers with a try catch that:
+This example shows how to have foo-foo-mq wrap all handlers with a try catch that:
 
  * nacks the message on error
  * console.log that an error has occurred in a handle
@@ -99,7 +99,7 @@ The default behavior is that any message received that doesn't have any elligibl
 
 To avoid unhandled message churn, select one of the following mutually exclusive strategies:
 
-### `rabbot.onUnhandled( handler )`
+### `rabbit.onUnhandled( handler )`
 
 ```javascript
 rabbit.onUnhandled( function( message ) {
@@ -107,14 +107,14 @@ rabbit.onUnhandled( function( message ) {
 } );
 ```
 
-### `rabbot.nackUnhandled()` - default
+### `rabbit.nackUnhandled()` - default
 
 Sends all unhandled messages back to the queue.
 ```javascript
 rabbit.nackUnhandled();
 ```
 
-### `rabbot.rejectUnhandled()`
+### `rabbit.rejectUnhandled()`
 
 Rejects unhandled messages so that will will _not_ be requeued. **DO NOT** use this unless there are dead letter exchanges for all queues.
 ```javascript
@@ -125,7 +125,7 @@ rabbit.rejectUnhandled();
 
 Unroutable messages that were published with `mandatory: true` will be returned. These messages cannot be ack/nack'ed.
 
-### `rabbot.onReturned( handler )`
+### `rabbit.onReturned( handler )`
 
 ```javascript
 rabbit.onReturned( function( message ) {
@@ -133,7 +133,7 @@ rabbit.onReturned( function( message ) {
 } );
 ```
 
-## `rabbot.startSubscription( queueName, [exclusive], [connectionName] )`
+## `rabbit.startSubscription( queueName, [exclusive], [connectionName] )`
 
 > Recommendation: set handlers for anticipated types up before starting subscriptions.
 
@@ -160,13 +160,13 @@ The following structure shows and briefly explains the format of the message tha
   },
   properties:{
     contentType: "application/json", // see serialization for how defaults are determined
-    contentEncoding: "utf8", // rabbot's default
+    contentEncoding: "utf8", // foo-foo-mq's default
     headers: {}, // any user provided headers
     correlationId: "", // the correlation id if provided
     replyTo: "", // the reply queue would go here
     messageId: "", // message id if provided
     type: "", // the type of the message published
-    appId: "" // not used by rabbot
+    appId: "" // not used by foo-foo-mq
   },
   content: { "type": "Buffer", "data": [ ... ] }, // raw buffer of message body
   body: , // this could be an object, string, etc - whatever was published
@@ -175,17 +175,17 @@ The following structure shows and briefly explains the format of the message tha
 }
 ```
 
-## `rabbot.stopSubscription( queueName, [connectionName] )`
+## `rabbit.stopSubscription( queueName, [connectionName] )`
 
 > !Caution!:
 > * This does not affect bindings to the queue, it only stops the flow of messages from the queue to your service.
 > * If the queue is auto-delete, this will destroy the queue, dropping messages and losing any messages sent that would have been routed to it.
 > * If a network disruption has occurred or does occur, subscription will be restored to its last known state.
 
-Stops consuming messages from the queue. Does not explicitly change bindings on the queue. Does not explicitly release the queue or the channel used to establish the queue. In general, Rabbot works best when queues exist for the lifetime of a service. Starting and stopping queue subscriptions is likely to produce unexpected behaviors (read: avoid it).
+Stops consuming messages from the queue. Does not explicitly change bindings on the queue. Does not explicitly release the queue or the channel used to establish the queue. In general, Foo-foo-mq works best when queues exist for the lifetime of a service. Starting and stopping queue subscriptions is likely to produce unexpected behaviors (read: avoid it).
 
 ## Message API
-rabbot defaults to (and assumes) queues are in ack mode. It batches ack and nack operations in order to improve total throughput. Ack/Nack calls do not take effect immediately.
+foo-foo-mq defaults to (and assumes) queues are in ack mode. It batches ack and nack operations in order to improve total throughput. Ack/Nack calls do not take effect immediately.
 
 ### `message.ack()`
 Enqueues the message for acknowledgement.
@@ -211,17 +211,17 @@ The options hash can specify additional information about the reply and has the 
 ```
 
 ### Queues in `noBatch` mode
-rabbot now supports the ability to put queues into non-batching behavior. This causes ack, nack and reject calls to take place against the channel immediately. This feature is ideal when processing messages are long-running and consumer limits are in place. Be aware that this feature does have a significant impact on message throughput.
+foo-foo-mq now supports the ability to put queues into non-batching behavior. This causes ack, nack and reject calls to take place against the channel immediately. This feature is ideal when processing messages are long-running and consumer limits are in place. Be aware that this feature does have a significant impact on message throughput.
 
 ## Reply Queues
-By default, rabbot creates a unique reply queue for each connection which is automatically subscribed to and deleted on connection close. This can be modified or turned off altogether.
+By default, foo-foo-mq creates a unique reply queue for each connection which is automatically subscribed to and deleted on connection close. This can be modified or turned off altogether.
 
 Changing the behavior is done by passing one of three values to the `replyQueue` property on the connection hash:
 
-> !!! IMPORTANT !!! rabbot cannot prevent queue naming collisions across services instances or connections when using the first two options.
+> !!! IMPORTANT !!! foo-foo-mq cannot prevent queue naming collisions across services instances or connections when using the first two options.
 
 ### Custom Name
-Only changes the name of the reply queue that rabbot creates - `autoDelete` and `subscribe` will be set to `true`.
+Only changes the name of the reply queue that foo-foo-mq creates - `autoDelete` and `subscribe` will be set to `true`.
 
 ```javascript
 rabbit.addConnection( {
@@ -233,7 +233,7 @@ rabbit.addConnection( {
 ### Custom Behavior
 To take full control of the queue name and behavior, provide a queue definition in place of the name.
 
-> rabbot provides no defaults - it will only use the definition provided
+> foo-foo-mq provides no defaults - it will only use the definition provided
 
 ```javascript
 rabbit.addConnection( {
@@ -258,19 +258,19 @@ rabbit.addConnection( {
 
 ## Custom Serializers
 
-Serializers are objects with a `serialize` and `deserialize` method and get assigned to a specific content type. When a message is published or received with a specific `content-type`, rabbot will attempt to look up a serializer that matches. If one isn't found, an error will get thrown.
+Serializers are objects with a `serialize` and `deserialize` method and get assigned to a specific content type. When a message is published or received with a specific `content-type`, foo-foo-mq will attempt to look up a serializer that matches. If one isn't found, an error will get thrown.
 
-> Note: you can over-write rabbot's default serializers but probably shouldn't unless you know what you're doing.
+> Note: you can over-write foo-foo-mq's default serializers but probably shouldn't unless you know what you're doing.
 
-### `rabbot.serialize( object )`
+### `rabbit.serialize( object )`
 
 The serialize function takes the message content and must return a Buffer object encoded as "utf8".
 
-### `rabbot.deserialize( bytes, encoding )`
+### `rabbit.deserialize( bytes, encoding )`
 
-The deserialize function takes both the raw bytes and the encoding sent. While "utf8" is the only supported encoding rabbot produces, the encoding is passed in case the message was produced by another library using a different encoding.
+The deserialize function takes both the raw bytes and the encoding sent. While "utf8" is the only supported encoding foo-foo-mq produces, the encoding is passed in case the message was produced by another library using a different encoding.
 
-### `rabbot.addSerializer( contentType, serializer )`
+### `rabbit.addSerializer( contentType, serializer )`
 
 ```javascript
 var yaml = require( "js-yaml" );

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -2,7 +2,7 @@
 
 ## Configuration via JSON (recommended)
 
-This is the recommended approach to creating topology with rabbot. Configuration should only happen once per service. If a disconnect takes place, rabbot will attempt to re-establish the connection and all topology, including previously established subscriptions.
+This is the recommended approach to creating topology with foo-foo-mq. Configuration should only happen once per service. If a disconnect takes place, foo-foo-mq will attempt to re-establish the connection and all topology, including previously established subscriptions.
 
 > Note: setting subscribe to true will result in subscriptions starting immediately upon queue creation; be sure to have handlers created *before hand*.
 
@@ -37,14 +37,14 @@ This example shows most of the available options described above.
 
 To establish a connection with all settings in place and ready to go call configure:
 ```javascript
-  var rabbit = require( "rabbot" );
+  var rabbit = require( "foo-foo-mq" );
 
   rabbit.configure( settings ).done( function() {
     // ready to go!
   } );
 ```
 
-## `rabbot.addExchange( exchangeName, exchangeType, [options], [connectionName] )`
+## `rabbit.addExchange( exchangeName, exchangeType, [options], [connectionName] )`
 
 The call returns a promise that can be used to determine when the exchange has been created on the server.
 
@@ -64,9 +64,9 @@ Options is a hash that can contain the following:
 | **publishTimeout** | 2^32 | timeout in milliseconds for publish calls to this exchange ||
 | **replyTimeout** | 2^32 | timeout in milliseconds to wait for a reply | |
 | **limit** | 2^16 | the number of unpublished messages to cache while waiting on connection | |
-| **noConfirm** | boolean | prevents rabbot from creating the exchange in confirm mode | false |
+| **noConfirm** | boolean | prevents foo-foo-mq from creating the exchange in confirm mode | false |
 
-## `rabbot.addQueue( queueName, [options], [connectionName] )`
+## `rabbit.addQueue( queueName, [options], [connectionName] )`
 
 The call returns a promise that can be used to determine when the queue has been created on the server.
 
@@ -105,40 +105,40 @@ The unique option has 3 different possible values, each with its own behavior:
 You can specify unique queues by their friendly-name when handling and subscribing. To get the actual assigned queue name (which you should not need), you can use:
 
 ```js
-const realQueueName = rabbot.getQueue('friendly-q-name').uniqueName;
+const realQueueName = rabbit.getQueue('friendly-q-name').uniqueName;
 ```
 
 ### poison
 
-If you want to capture instances where messages have no serializer or failed to deserialize properly, you can create a dead-letter exchange and bind it to a queue where you set `poison: true` so that in the event of further errors, rabbot will continue to deliver the message without deserialization.
+If you want to capture instances where messages have no serializer or failed to deserialize properly, you can create a dead-letter exchange and bind it to a queue where you set `poison: true` so that in the event of further errors, foo-foo-mq will continue to deliver the message without deserialization.
 
  * `body` will be set to the raw Buffer
  * `quarantine` will be set to `true` as well
 
-## `rabbot.bindExchange( sourceExchange, targetExchange, [routingKeys], [connectionName] )`
+## `rabbit.bindExchange( sourceExchange, targetExchange, [routingKeys], [connectionName] )`
 
 Binds the target exchange to the source exchange. Messages flow from source to target.
 
-## `rabbot.bindQueue( sourceExchange, targetQueue, [routingKeys], [connectionName] )`
+## `rabbit.bindQueue( sourceExchange, targetQueue, [routingKeys], [connectionName] )`
 
 Binds the target queue to the source exchange. Messages flow from source to target.
 
-## `rabbot.purgeQueue( queueName, [connectionName] )`
+## `rabbit.purgeQueue( queueName, [connectionName] )`
 
-Returns a promise that will resolve to the number of purged messages. Purging is a very complicated operation and should not be used without an appreciation for nuances in how amqp delivery and rabbot's ack system works.
+Returns a promise that will resolve to the number of purged messages. Purging is a very complicated operation and should not be used without an appreciation for nuances in how amqp delivery and foo-foo-mq's ack system works.
 
-When purge is called in rabbot, first it checks to see if any messages are in the queue before it bothers moving on to try to purge. "That's a race condition!" - right, but so is purging.
+When purge is called in foo-foo-mq, first it checks to see if any messages are in the queue before it bothers moving on to try to purge. "That's a race condition!" - right, but so is purging.
 
-Purging in rabbot does _not_ remove the queue bindings for you. **If** the queue is marked as `autoDelete: true`, rabbot cannot even stop the subscription for you because doing so will cause the queue to be deleted, removing its bindings and any upstream exchanges bound to it marked with `autoDelete: true` that don't have other bindings at the moment.
+Purging in foo-foo-mq does _not_ remove the queue bindings for you. **If** the queue is marked as `autoDelete: true`, foo-foo-mq cannot even stop the subscription for you because doing so will cause the queue to be deleted, removing its bindings and any upstream exchanges bound to it marked with `autoDelete: true` that don't have other bindings at the moment.
 
-In the even that the queue isn't `autoDelete`, the subscription will be halted for the duration of the purge operation and then rabbot will attempt to re-establish subscription to the queue after.
+In the even that the queue isn't `autoDelete`, the subscription will be halted for the duration of the purge operation and then foo-foo-mq will attempt to re-establish subscription to the queue after.
 
 Anytime lots of operations are taking place against an amqp channel, there are opportunities for unexpected behaviors in terms of message arrival or even channel loss. It's important to understand the context you're in when calling `purgeQueue` and I recommend limiting its application.
 
 ## Channel Prefetch Limits
 
-rabbot mostly hides the notion of a channel behind the scenes, but still allows you to specify channel options such as the channel prefetch limit. Rather than specifying
-this on a channel object, however, it is specified as a `limit` on a queue defintion.
+foo-foo-mq mostly hides the notion of a channel behind the scenes, but still allows you to specify channel options such as the channel prefetch limit. Rather than specifying
+this on a channel object, however, it is specified as a `limit` on a queue definition.
 
 ```js
 queues: [{


### PR DESCRIPTION
more renaming