### PR TITLE
chore: update repo url references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,26 +32,26 @@ This is a very opinionated abstraction over amqplib to help simplify the impleme
 
 ## Documentation You Should Read
 
- * [Connection Management](https://github.com/zlintz/foo-foo-mq/blob/master/docs/connections.md) - connection management
- * [Topology Setup](https://github.com/zlintz/foo-foo-mq/blob/master/docs/topology.md) - topology configuration
- * [Publishing Guide](https://github.com/zlintz/foo-foo-mq/blob/master/docs/publishing.md) - publishing and requesting
- * [Receiving Guide](https://github.com/zlintz/foo-foo-mq/blob/master/docs/receiving.md) - subscribing and handling of messages
- * [Logging](https://github.com/zlintz/foo-foo-mq/blob/master/docs/logging.md) - how foo-foo-mq logs
+ * [Connection Management](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/docs/connections.md) - connection management
+ * [Topology Setup](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/docs/topology.md) - topology configuration
+ * [Publishing Guide](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/docs/publishing.md) - publishing and requesting
+ * [Receiving Guide](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/docs/receiving.md) - subscribing and handling of messages
+ * [Logging](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/docs/logging.md) - how foo-foo-mq logs
 
 ## Other Documents
 
- * [Contributor Guide](https://github.com/zlintz/foo-foo-mq/blob/master/HOW_TO_CONTRIBUTE.md)
- * [Code of Conduct](https://github.com/zlintz/foo-foo-mq/blob/master/CODE_OF_CONDUCT.md)
- * [Resources](https://github.com/zlintz/foo-foo-mq/blob/master/RESOURCES.md)
- * [Maintainers](https://github.com/zlintz/foo-foo-mq/blob/master/MAINTAINERS.md)
- * [Contributors](https://github.com/zlintz/foo-foo-mq/blob/master/CONTRIBUTORS.md)
- * [Acknowledgements](https://github.com/zlintz/foo-foo-mq/blob/master/ACKNOWLEDGEMENTS.md)
- * [Change Log](https://github.com/zlintz/foo-foo-mq/blob/master/CHANGELOG.md)
- * [Differences From Wascally](https://github.com/zlintz/foo-foo-mq/blob/master/docs/notwascally.md)
+ * [Contributor Guide](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/HOW_TO_CONTRIBUTE.md)
+ * [Code of Conduct](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/CODE_OF_CONDUCT.md)
+ * [Resources](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/RESOURCES.md)
+ * [Maintainers](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/MAINTAINERS.md)
+ * [Contributors](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/CONTRIBUTORS.md)
+ * [Acknowledgements](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/ACKNOWLEDGEMENTS.md)
+ * [Change Log](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/CHANGELOG.md)
+ * [Differences From Wascally](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/docs/notwascally.md)
 
 ## Demos
 
- * [pubsub](https://github.com/zlintz/foo-foo-mq/blob/master/demo/pubsub/README.md)
+ * [pubsub](https://github.com/Foo-Foo-MQ/foo-foo-mq/blob/master/demo/pubsub/README.md)
 
 ## API Example
 
@@ -114,13 +114,13 @@ setTimeout(() => {
  * improve support RabbitMQ backpressure mechanisms
  * add support for Rabbit's HTTP API
 
-[travis-image]: https://travis-ci.org/zlintz/foo-foo-mq.svg?branch=master
-[travis-url]: https://travis-ci.org/zlintz/foo-foo-mq
-[coveralls-url]: https://coveralls.io/github/zlintz/foo-foo-mq?branch=master
-[coveralls-image]: https://coveralls.io/repos/github/zlintz/foo-foo-mq/badge.svg?branch=master
+[travis-image]: https://travis-ci.org/Foo-Foo-MQ/foo-foo-mq.svg?branch=master
+[travis-url]: https://travis-ci.org/Foo-Foo-MQ/foo-foo-mq
+[coveralls-url]: https://coveralls.io/github/Foo-Foo-MQ/foo-foo-mq?branch=master
+[coveralls-image]: https://coveralls.io/repos/github/Foo-Foo-MQ/foo-foo-mq/badge.svg?branch=master
 [version-image]: https://img.shields.io/npm/v/foo-foo-mq.svg?style=flat
 [version-url]: https://www.npmjs.com/package/foo-foo-mq
 [downloads-image]: https://img.shields.io/npm/dm/foo-foo-mq.svg?style=flat
 [downloads-url]: https://www.npmjs.com/package/foo-foo-mq
-[dependencies-image]: https://img.shields.io/david/zlintz/foo-foo-mq.svg?style=flat
-[dependencies-url]: https://david-dm.org/zlintz/foo-foo-mq
+[dependencies-image]: https://img.shields.io/david/Foo-Foo-MQ/foo-foo-mq.svg?style=flat
+[dependencies-url]: https://david-dm.org/Foo-Foo-MQ/foo-foo-mq

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=10 <=12"
   },
-  "repository": "https://github.com/zlintz/foo-foo-mq",
+  "repository": "https://github.com/Foo-Foo-MQ/foo-foo-mq",
   "scripts": {
     "lint": "semistandard",
     "lint-fix": "semistandard --fix",


### PR DESCRIPTION
When the repo was moved from `zlintz/foo-foo-mq` to `Foo-Foo-MQ/foo-foo-mq`, the URLs in the README and package were no updated.

This PR updates the urls to `Foo-Foo-MQ/foo-foo-mq` in both places. 