### PR TITLE
fix(amqp/connection.js): map call wasn't returning values for caPaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "commit": "git-cz",
     "coverage": "nyc npm test",
     "release": "standard-version",
+    "release:dry": "standard-version --dry-run",
     "build-image": "docker build -t foofoomq .",
     "create-container": "docker run -d --name foofoomq -p 15672:15672 -p 5672:5672 foofoomq",
     "bootstrap-container": "npm run build-image && npm run create-container",

--- a/spec/behavior/ssl/ssl-connection.spec.js
+++ b/spec/behavior/ssl/ssl-connection.spec.js
@@ -1,0 +1,129 @@
+require('../../setup');
+const fs = require('fs');
+const ampqlib = require('amqplib');
+const rabbit = require('../../../src/index.js');
+const config = require('../../integration/configuration');
+
+describe('AMQP Connection', function () {
+  describe('ssl support options when values are not paths', function () {
+    let sandbox;
+    let amqplibConnectSpy;
+
+    before(function (done) {
+      sandbox = sinon.createSandbox();
+      amqplibConnectSpy = sandbox.stub(ampqlib, 'connect').rejects();
+      rabbit.configure({
+        connection: {
+          ...config.connection,
+          retryLimit: 1,
+          caPath: 'some-ca-value',
+          certPath: 'cert',
+          keyPath: 'key',
+          pfxPath: 'pfx',
+          passphrase: 'passphrase-is-not-a-path'
+        }
+      })
+        .catch(() => {
+          done();
+        });
+    });
+
+    after(() => {
+      sandbox.restore();
+    });
+
+    it('should have all of the provided ssl options', function () {
+      const uri = 'amqps://guest:guest@127.0.0.1:5672/%2f?heartbeat=30';
+
+      const expectedConnectionOptions = {
+        servername: '127.0.0.1',
+        noDelay: true,
+        timeout: 2000,
+        cert: 'cert',
+        key: 'key',
+        pfx: 'pfx',
+        passphrase: 'passphrase-is-not-a-path',
+        ca: [
+          'some-ca-value'
+        ],
+        clientProperties: {
+          host: sinon.match.string,
+          process: sinon.match.string,
+          lib: sinon.match(/foo-foo-mq - .*/)
+        }
+      };
+
+      sinon.assert.callCount(amqplibConnectSpy, 1);
+      sinon.assert.calledWith(amqplibConnectSpy, uri, expectedConnectionOptions);
+    });
+  });
+
+  describe('ssl support options when values are paths', function () {
+    let amqplibConnectSpy;
+    let sandbox;
+    const getLocalPath = (fileName) => `${__dirname}/${fileName}`;
+    let sslPathSettings = [
+      getLocalPath('caPath1'),
+      getLocalPath('caPath2'),
+      getLocalPath('certPath'),
+      getLocalPath('keyPath'),
+      getLocalPath('pfxPath')
+    ];
+
+    before(function (done) {
+      sandbox = sinon.createSandbox();
+      sslPathSettings.map((settingName) => {
+        fs.writeFileSync(settingName, `${settingName.split('/').pop()}-file-contents`);
+      });
+
+      amqplibConnectSpy = sandbox.stub(ampqlib, 'connect').rejects();
+      rabbit.configure({
+        connection: {
+          ...config.connection,
+          retryLimit: 1,
+          caPath: `${sslPathSettings[0]},${sslPathSettings[1]}`,
+          certPath: sslPathSettings[2],
+          keyPath: sslPathSettings[3],
+          pfxPath: sslPathSettings[4],
+          passphrase: 'passphrase-is-not-a-path'
+        }
+      })
+        .catch(() => {
+          done();
+        });
+    });
+
+    after(() => {
+      sslPathSettings.map((settingName) => {
+        fs.unlinkSync(settingName);
+      });
+      sandbox.restore();
+    });
+
+    it('should have all of the provided ssl options', function () {
+      const uri = 'amqps://guest:guest@127.0.0.1:5672/%2f?heartbeat=30';
+
+      const expectedConnectionOptions = {
+        servername: '127.0.0.1',
+        noDelay: true,
+        timeout: 2000,
+        cert: Buffer.from('certPath-file-contents'),
+        key: Buffer.from('keyPath-file-contents'),
+        pfx: Buffer.from('pfxPath-file-contents'),
+        passphrase: 'passphrase-is-not-a-path',
+        ca: [
+          Buffer.from('caPath1-file-contents'),
+          Buffer.from('caPath2-file-contents')
+        ],
+        clientProperties: {
+          host: sinon.match.string,
+          process: sinon.match.string,
+          lib: sinon.match(/foo-foo-mq - .*/)
+        }
+      };
+
+      sinon.assert.callCount(amqplibConnectSpy, 1);
+      sinon.assert.calledWith(amqplibConnectSpy, uri, expectedConnectionOptions);
+    });
+  });
+});

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -92,6 +92,10 @@ function trim (x) {
   return x.trim(' ');
 }
 
+function readFromFileIfPathOrDefaultToInput (possiblePathOrValue) {
+  return fs.existsSync(possiblePathOrValue) ? fs.readFileSync(possiblePathOrValue) : possiblePathOrValue;
+}
+
 const Adapter = function (parameters) {
   var uriOpts = parseUri(parameters.uri);
   Object.assign(parameters, uriOpts);
@@ -122,22 +126,20 @@ const Adapter = function (parameters) {
     this.options.timeout = timeout;
   }
   if (certPath) {
-    this.options.cert = fs.existsSync(certPath) ? fs.readFileSync(certPath) : certPath;
+    this.options.cert = readFromFileIfPathOrDefaultToInput(certPath);
   }
   if (keyPath) {
-    this.options.key = fs.existsSync(keyPath) ? fs.readFileSync(keyPath) : keyPath;
+    this.options.key = readFromFileIfPathOrDefaultToInput(keyPath);
   }
   if (passphrase) {
     this.options.passphrase = passphrase;
   }
   if (pfxPath) {
-    this.options.pfx = fs.existsSync(pfxPath) ? fs.readFileSync(pfxPath) : pfxPath;
+    this.options.pfx = readFromFileIfPathOrDefaultToInput(pfxPath);
   }
   if (caPaths) {
     const list = caPaths.split(',');
-    this.options.ca = list.map((caPath) => {
-      fs.existsSync(caPath) ? fs.readFileSync(caPath) : caPath; // eslint-disable-line no-unused-expressions
-    });
+    this.options.ca = list.map(readFromFileIfPathOrDefaultToInput);
   }
   if (useSSL) {
     this.protocol = 'amqps://';

--- a/src/amqp/iomonad.js
+++ b/src/amqp/iomonad.js
@@ -2,7 +2,7 @@
 
 const Monologue = require('node-monologue');
 const machina = require('machina');
-const log = require('../log.js')('rabbot.io');
+const log = require('../log.js')('foo-foo-mq');
 let staticId = 0;
 
 /* state definitions
@@ -23,7 +23,7 @@ let staticId = 0;
 */
 
 /* log:
-  * `rabbot.io`
+  * `foo-foo-mq`
     * `debug`:
       * attempting acquisition
       * successful acquisition

--- a/src/info.js
+++ b/src/info.js
@@ -44,7 +44,7 @@ function getProcessInfo () {
 }
 
 function getLibInfo () {
-  return format('rabbot - %s', self.version);
+  return format('foo-foo-mq - %s', self.version);
 }
 
 module.exports = {


### PR DESCRIPTION
The caPaths connection option wasn't being returned in the map call resulting in an empty ca value
for ssl connections