### PR TITLE
fix(connection.js): correct accessor for username and password

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,10 @@ spec/
 plato/
 coverage/
 .vagrant/
-.idea
+.idea/
+.nyc_output/
+.editorconfig
+.travis.yml
+.nvmrc
+Dockerfile
+

--- a/spec/integration/badConnection.spec.js
+++ b/spec/integration/badConnection.spec.js
@@ -33,6 +33,28 @@ describe('Bad Connection', function () {
     after(() => rabbit.close('silly', true));
   });
 
+  describe('when attempting a uri connection with an invalid password', function () {
+    var error;
+    before((done) => {
+      rabbit.once('#.connection.failed', (err) => {
+        error = err;
+        done();
+      });
+
+      rabbit.addConnection({
+        name: 'noauthz',
+        uri: 'amqp://guest:notguest@localhost:5672/%2f?heartbeat=10'
+      })
+        .catch(noop);
+    });
+
+    it('should fail to connect', () => {
+      error.should.equal('No endpoints could be reached');
+    });
+
+    after(() => rabbit.close('noauthz', true));
+  });
+
   describe('when configuring against a bad connection', function () {
     var config;
     before(() => {

--- a/spec/integration/connection.spec.js
+++ b/spec/integration/connection.spec.js
@@ -4,7 +4,7 @@ const config = require('./configuration');
 
 describe('Connection', function () {
   describe('on connection', function () {
-    var connected;
+    let connected;
     before(function (done) {
       rabbit.once('connected', (c) => {
         connected = c;
@@ -19,6 +19,25 @@ describe('Connection', function () {
 
     after(function () {
       return rabbit.close('default');
+    });
+  });
+
+  describe('on connection using uri', function () {
+    let connected;
+    before(function (done) {
+      rabbit.once('connected', (c) => {
+        connected = c;
+        done();
+      });
+      rabbit.addConnection({ name: 'connectionWithUri', uri: 'amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=11' });
+    });
+
+    it('should assign uri to connection', function () {
+      connected.uri.should.equal('amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=11');
+    });
+
+    after(function () {
+      return rabbit.close('connectionWithUri');
     });
   });
 });

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -59,13 +59,12 @@ function max (x, y) {
 
 function parseUri (uri) {
   if (uri) {
-    var parsed = new url.URL(uri);
-    var authSplit = parsed.auth ? parsed.auth.split(':') : [null, null];
-    var heartbeat = parsed.query ? parsed.query.split('&')[0].split('=')[1] : null;
+    const parsed = new url.URL(uri);
+    const heartbeat = parsed.searchParams.get('heartbeat');
     return {
       useSSL: parsed.protocol === 'amqps:',
-      user: authSplit[0],
-      pass: authSplit[1],
+      user: parsed.username,
+      pass: parsed.password,
       host: parsed.hostname,
       port: parsed.port,
       vhost: parsed.pathname ? parsed.pathname.slice(1) : undefined,


### PR DESCRIPTION
moving to the URL class broke uri connections since `auth` is not on the class as was when using
url.parse on the legecy urlObject, this also exposed a search param bug as well meaning the
heartbeat was not being respected

fix #14