### PR TITLE
Bubble channel failures up to the connection

### DIFF
--- a/src/connectionFsm.js
+++ b/src/connectionFsm.js
@@ -68,6 +68,10 @@ const Connection = function (options, connectionFn, channelFn) {
           channel.on('return', (raw) => {
             this.emit('return', raw);
           });
+          channel.on('failed', () => {
+            this.transition('failed');
+            this.handle('failed');
+          });
         });
       } else {
         return Promise.resolve(channel);


### PR DESCRIPTION
Send channel failures up to the connection so that they can be handled
appropriately. Previously, errors on channels caused silent failures
which could result in queues being unable to receive messages without
any indication of failure, such as described in
https://github.com/arobson/rabbot/issues/155.

This approach is a bit naive in that it causes the whole connection to
fail when an a single channel fails, but I don't think the abstractions
in this library allow for the user to respond to channel-level events.

In my case, this type of failure occurred any time my consumers lost
their connection to the RabbitMQ cluster and tried to send an ack for an
old delivery tag to a different RMQ node in the cluster (i.e. queue is
re-established on new node and batch acks send after reconnecting). This
would result in the following error in amqplib:

    Error: Channel closed by server: 406 (PRECONDITION-FAILED) with message "PRECONDITION_FAILED - unknown delivery tag 42"

But from the perspective of foo-foo-mq/rabbot, everything was fine. With
these changes in place, I can at least listen for a `failed` event on
the broker and respond appropriately.