### PR TITLE
Fix port resolving on amqps:// protocol

### DIFF
--- a/spec/behavior/ssl/ssl-connection.spec.js
+++ b/spec/behavior/ssl/ssl-connection.spec.js
@@ -20,7 +20,8 @@ describe('AMQP Connection', function () {
           certPath: 'cert',
           keyPath: 'key',
           pfxPath: 'pfx',
-          passphrase: 'passphrase-is-not-a-path'
+          passphrase: 'passphrase-is-not-a-path',
+          port: null // To check the port is auto-resolved correctly to 5671
         }
       })
         .catch(() => {
@@ -33,7 +34,7 @@ describe('AMQP Connection', function () {
     });
 
     it('should have all of the provided ssl options', function () {
-      const uri = 'amqps://guest:guest@127.0.0.1:5672/%2f?heartbeat=30';
+      const uri = 'amqps://guest:guest@127.0.0.1:5671/%2f?heartbeat=30';
 
       const expectedConnectionOptions = {
         servername: '127.0.0.1',

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -102,14 +102,11 @@ const Adapter = function (parameters) {
   const servers = getOption(parameters, 'server');
   const brokers = getOption(parameters, 'RABBIT_BROKER');
   const serverList = brokers || hosts || servers || 'localhost';
-  const portList = getOption(parameters, 'RABBIT_PORT') || getOption(parameters, 'port', 5672);
 
   this.name = parameters ? (parameters.name || 'default') : 'default';
   this.servers = split(serverList);
   this.connectionIndex = getInitialIndex(this.servers.length);
-  this.ports = split(portList);
   this.heartbeat = getOption(parameters, 'RABBIT_HEARTBEAT') || getOption(parameters, 'heartbeat', 30);
-  this.protocol = getOption(parameters, 'RABBIT_PROTOCOL') || getOption(parameters, 'protocol', 'amqp://');
   this.pass = getOption(parameters, 'RABBIT_PASSWORD') || getOption(parameters, 'pass', 'guest');
   this.user = getOption(parameters, 'RABBIT_USER') || getOption(parameters, 'user', 'guest');
   this.vhost = getOption(parameters, 'RABBIT_VHOST') || getOption(parameters, 'vhost', '%2f');
@@ -120,7 +117,11 @@ const Adapter = function (parameters) {
   const passphrase = getOption(parameters, 'RABBIT_PASSPHRASE') || getOption(parameters, 'passphrase');
   const pfxPath = getOption(parameters, 'RABBIT_PFX') || getOption(parameters, 'pfxPath');
   const useSSL = certPath || keyPath || passphrase || caPaths || pfxPath || parameters.useSSL;
+  const portList = getOption(parameters, 'RABBIT_PORT') || getOption(parameters, 'port', (useSSL ? 5671 : 5672));
+  this.protocol = getOption(parameters, 'RABBIT_PROTOCOL') || (useSSL ? 'amqps://' : 'amqp://');
+  this.ports = split(portList);
   this.options = { noDelay: true };
+
   if (timeout) {
     this.options.timeout = timeout;
   }
@@ -139,9 +140,6 @@ const Adapter = function (parameters) {
   if (caPaths) {
     const list = caPaths.split(',');
     this.options.ca = list.map(readFromFileIfPathOrDefaultToInput);
-  }
-  if (useSSL) {
-    this.protocol = 'amqps://';
   }
   this.options.clientProperties = Object.assign({
     host: info.host(),


### PR DESCRIPTION
As suggested by Cloudamqp support person, `foo-foo-mq` should correctly auto-resolve the ssl port to `5671` instead of the standard `5672`. This replicate the same behavior as amqplib: https://github.com/squaremo/amqp.node/blob/e3e10167d3f498f632a5a50dc7fac62b314400c8/lib/connect.js#L109