### PR TITLE
fix(types): add waitMax to ConnectionOptions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -212,6 +212,7 @@ declare namespace Broker {
     failAfter?: number;
     retryLimit?: number;
     waitMin?: number;
+    waitMax?: number;
     waitIncrement?: number;
     clientProperties?: any;
     caPath?: string;


### PR DESCRIPTION
After upgrading to a TS supported version of foo-foo-mq, we receive the following TSC error:
`Object literal may only specify known properties, and 'waitMax' does not exist in type 'ConnectionOptions'`

The issue appears to be that the foo-foo-mq types are missing the `ConnectionOptions.waitMax` property although it should be there. This PR addresses this issue.