### PR TITLE
fix: Issue #26 and #55 and add missing fields in type definition + quorum support

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -147,7 +147,7 @@ Your goal should be building systems resilient to failures (by allowing them to 
 
 ```js
 // How to create a zombie
-var rabbit = require( "foo-foo-mq" );
+const rabbit = require( "foo-foo-mq" );
 
 rabbit.on( "unreachable", function() {
   rabbit.retry();

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -20,7 +20,7 @@ Options is a hash that can contain the following:
 | **host** | the IP address or DNS name of the RabbitMQ server. | `"localhost"` |
 | **port** | the TCP/IP port on which RabbitMQ is listening. | `5672` |
 | **vhost** | the named vhost to use in RabbitMQ. | `"%2f"` ~ `"/"` |
-| **protocol** | the connection protocol to use. | `"amqp://"` |
+| **protocol** | the connection protocol to use. | `"amqp"` |
 | **user** | the username used for authentication / authorization with this connection | `"guest"` |
 | **pass** | the password for the specified user. | `"guest"` |
 | **timeout** | how long to wait for a connection to be established in milliseconds. | `2000` |

--- a/docs/receiving.md
+++ b/docs/receiving.md
@@ -42,7 +42,7 @@ If using the first form, the options hash can contain the following properties, 
 In this example, any possible error is caught in an explicit try/catch:
 
 ```javascript
-var handler = rabbit.handle( "company.project.messages.logEntry", function( message ) {
+const handler = rabbit.handle( "company.project.messages.logEntry", function( message ) {
   try {
     // do something meaningful?
     console.log( message.body );
@@ -67,7 +67,7 @@ This example shows how to have foo-foo-mq wrap all handlers with a try catch tha
 // that nacks the message on an error
 rabbit.nackOnError();
 
-var handler = rabbit.handle( "company.project.messages.logEntry", function( message ) {
+const handler = rabbit.handle( "company.project.messages.logEntry", function( message ) {
   console.log( message.body );
   message.ack();
 } );
@@ -83,7 +83,7 @@ rabbit.ignoreHandlerErrors();
 Provide a strategy for handling errors to multiple handles or attach an error handler after the fact.
 
 ```javascript
-var handler = rabbit.handle( "company.project.messages.logEntry", function( message ) {
+const handler = rabbit.handle( "company.project.messages.logEntry", function( message ) {
   console.log( message.body );
   message.ack();
 } );
@@ -299,7 +299,7 @@ the encoding is passed in case the message was produced by another library using
 ### `rabbit.addSerializer( contentType, serializer )`
 
 ```javascript
-var yaml = require( "js-yaml" );
+const yaml = require( "js-yaml" );
 
 rabbit.addSerializer( "application/yaml", {
   deserialize: function( bytes, encoding ) {

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -10,7 +10,7 @@ If a disconnect takes place, foo-foo-mq will attempt to re-establish the connect
 
 This example shows most of the available options described above.
 ```javascript
-  var settings = {
+  const settings = {
     connection: {
       user: "guest",
       pass: "guest",
@@ -39,7 +39,7 @@ This example shows most of the available options described above.
 
 To establish a connection with all settings in place and ready to go call configure:
 ```javascript
-  var rabbit = require( "foo-foo-mq" );
+  const rabbit = require( "foo-foo-mq" );
 
   rabbit.configure( settings ).done( function() {
     // ready to go!
@@ -74,8 +74,15 @@ The call returns a promise that can be used to determine when the queue has been
 
 Options is a hash that can contain the following:
 
+> **WARNING** classic queues [are deprecated](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements) and will [no longer be supported after v3.13](https://www.rabbitmq.com/blog/2024/03/11/rabbitmq-3.13.0-announcement#thats-a-wrap-for-3x).
+>
+> Unsupported options ('exclusive', 'autoDelete', 'maxPriority') given to `quorum` queues will be *silently ignored*.
+>
+> Consult the [RabbitMQ feature matrix](https://www.rabbitmq.com/docs/quorum-queues#feature-matrix) for supported features.
+
 | option | type | description | default  |
 |--:|:-:|:--|:-:|
+| **type** | string | Set the queue type to either `classic` or `quorum` | `classic` |
 | **autoDelete** | boolean | delete when consumer count goes to 0 | |
 | **durable** | boolean | survive broker restarts | false |
 | **exclusive** | boolean | limits queue to the current connection only (danger) | false |
@@ -93,7 +100,6 @@ Options is a hash that can contain the following:
 | **unique** | `"hash", `"id", "consistent"` | creates a unique queue name by including the client id or hash in the name | |
 | **poison** | boolean | indicates that this queue is specifically for poison / rejected messages| false |
 | **passive** | boolean | when `true` will not create the queueName specified | false |
-| **type** | string | Set the queue type to either `classic` or `quorum` | |
 
 ### unique
 

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -93,6 +93,7 @@ Options is a hash that can contain the following:
 | **unique** | `"hash", `"id", "consistent"` | creates a unique queue name by including the client id or hash in the name | |
 | **poison** | boolean | indicates that this queue is specifically for poison / rejected messages| false |
 | **passive** | boolean | when `true` will not create the queueName specified | false |
+| **type** | string | Set the queue type to either `classic` or `quorum` | |
 
 ### unique
 

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -77,15 +77,6 @@ async function tryConfigure(
   return rabbit;
 }
 
-// async/await
-try {
-  const broker = await tryConfigure(settings, { retries: 5, defer: 500 });
-    // ...
-} catch (err) {
-  console.log(err)
-}
-
-// Promise
 const rabbit = tryConfigure(settings, { retries: 5, defer: 500 });
   .then((broker) => {
     // ...

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -139,14 +139,27 @@ Options is a hash that can contain the following:
 | **noBatch** | boolean | causes ack, nack & reject to take place immediately | false |
 | **noCacheKeys** | boolean | disable cache of matched routing keys to prevent unbounded memory growth | false |
 | **queueLimit** | 2^32 |max number of ready messages a queue can hold | |
+| **overflow** | `drop-head`, `reject-publish` | Behavior when queue limit is reached, defaults to `drop-head`(discard oldest) | |
 | **messageTtl** | 2^32 |time in ms before a message expires on the queue | |
 | **expires** | 2^32 |time in ms before a queue with 0 consumers expires | |
 | **deadLetter** | string | the exchange to dead-letter messages to | |
 | **deadLetterRoutingKey** | string | the routing key to add to a dead-lettered message
+| **deadLetterStrategy** | `at-least-once`, `at-most-once` | the dead letter strategy, defaults to `at-most-once`.
 | **maxPriority** | 2^8 | the highest priority this queue supports | |
-| **unique** | `"hash", `"id", "consistent"` | creates a unique queue name by including the client id or hash in the name | |
+| **unique** | `hash`, `id`, `consistent` | creates a unique queue name by including the client id or hash in the name | |
 | **poison** | boolean | indicates that this queue is specifically for poison / rejected messages| false |
 | **passive** | boolean | when `true` will not create the queueName specified | false |
+
+### deadLetterStrategy
+
+ * `at-least-once` - enables [At-Least-Once Dead Lettering
+](https://www.rabbitmq.com/blog/2022/03/29/at-least-once-dead-lettering) since RabbitMQ v3.10 (**only** for quorum queues), provided the [feature flag](https://www.rabbitmq.com/docs/feature-flags) `stream_queue` is enabled an `overflow` is set to `reject-publish`
+ * `at-most-once` - the default strategy and backwards-compatible behavior
+
+### overflow
+
+ * `drop-head` - default behavior, drops or dead-letter messages from the front of the queue (i.e. the oldest messages in the queue)
+ * `reject-publish` - the most recently published messages will be discarded. In addition, if publisher confirms are enabled, the publisher will be informed of the reject via a basic.nack message
 
 ### unique
 

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -42,9 +42,10 @@ To establish a connection with all settings in place and ready to go call config
 ```javascript
   const rabbit = require( "foo-foo-mq" );
 
-  rabbit.configure( settings ).done( function() {
-    // ready to go!
-  } );
+  rabbit.configure( settings )
+    .then(() => {
+      // ready to go!
+    }).catch((err) => console.error(err))
 ```
 
 ### Caveat
@@ -61,12 +62,11 @@ async function tryConfigure(
   opts
 ) {
   const retries = opts.retries || 10;
-  const defer = opts.defer || 1e3;
   try {
     await rabbit.configure(settings);
   } catch (error) {
-    if (error === "No endpoints could be reached" && retries > 0) {
-      await setTimeout(defer);
+    if (retries > 0) {
+      if (opts.defer) await setTimeout(opts.defer);
       await rabbit.shutdown();
       await rabbit.reset();
       await this.tryConfigure(settings, { ...opts, retries: retries - 1 });
@@ -76,11 +76,6 @@ async function tryConfigure(
   }
   return rabbit;
 }
-
-const rabbit = tryConfigure(settings, { retries: 5, defer: 500 });
-  .then((broker) => {
-    // ...
-  }).catch((err) => console.error(err))
 ```
 
 ## `rabbit.addExchange( exchangeName, exchangeType, [options], [connectionName] )`

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -65,7 +65,7 @@ async function tryConfigure(
   try {
     await rabbit.configure(settings);
   } catch (error) {
-    if (retries > 0) {
+    if (error === 'No endpoints could be reached' && retries > 0) {
       if (opts.defer) await setTimeout(opts.defer);
       await rabbit.shutdown();
       await rabbit.reset();

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -106,9 +106,9 @@ The call returns a promise that can be used to determine when the queue has been
 
 Options is a hash that can contain the following:
 
-> **Warning:** classic queues [are deprecated](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements) and will no longer be supported [after v3.13](https://www.rabbitmq.com/blog/2024/03/11/rabbitmq-3.13.0-announcement#thats-a-wrap-for-3x).
+> **Warning:** Classic Mirrored Queues [are deprecated](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements) and will no longer be supported [after v3.13](https://www.rabbitmq.com/blog/2024/03/11/rabbitmq-3.13.0-announcement#thats-a-wrap-for-3x).
 >
-> As such, [unsupported options](https://www.rabbitmq.com/docs/quorum-queues#feature-matrix) (`exclusive`, `autoDelete`, `maxPriority`) given to quorum queues will be *silently ignored*.
+> For quorum queues, [unsupported options](https://www.rabbitmq.com/docs/quorum-queues#feature-matrix) (`exclusive`, `autoDelete`, `maxPriority`) given to quorum queues will be *silently ignored*.
 
 | option | type | description | default  |
 |--:|:-:|:--|:-:|
@@ -122,6 +122,7 @@ Options is a hash that can contain the following:
 | **noBatch** | boolean | causes ack, nack & reject to take place immediately | false |
 | **noCacheKeys** | boolean | disable cache of matched routing keys to prevent unbounded memory growth | false |
 | **queueLimit** | 2^32 |max number of ready messages a queue can hold | |
+| **queueVersion** | `1`, `2` | Sets queue version for classic queues original (CQv1) and new (CQv2) | |
 | **overflow** | `drop-head`, `reject-publish` | Behavior when queue limit is reached, defaults to `drop-head`(discard oldest) | |
 | **messageTtl** | 2^32 |time in ms before a message expires on the queue | |
 | **expires** | 2^32 |time in ms before a queue with 0 consumers expires | |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foo-foo-mq",
-  "version": "9.1.0",
+  "version": "9.0.3",
   "description": "Abstractions to simplify working with the RabbitMQ",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foo-foo-mq",
-  "version": "9.0.3",
+  "version": "9.1.0",
   "description": "Abstractions to simplify working with the RabbitMQ",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/spec/behavior/queue.spec.js
+++ b/spec/behavior/queue.spec.js
@@ -52,5 +52,23 @@ describe('AMQP Queue', function () {
           });
       });
     });
+
+    describe('when options.type is "quorum"', function () {
+      it('sets `x-queue-type` to "quorum" and omits incompatible fields', () => {
+        options.type = 'quorum';
+        options.queueLimit = 1000;
+        options.autoDelete = true;
+        options.maxPriority = 100;
+        return ampqQueue(options, topology, serializers)
+          .then((instance) => {
+            return instance.define();
+          })
+          .then(() => {
+            amqpChannelMock.assertQueue.calledWith(
+              options.uniqueName,
+              { queueLimit: options.queueLimit, arguments: { 'x-queue-type': options.type } });
+          });
+      });
+    });
   });
 });

--- a/spec/behavior/queue.spec.js
+++ b/spec/behavior/queue.spec.js
@@ -70,10 +70,53 @@ describe('AMQP Queue', function () {
       });
     });
 
+    describe('when options.type is "classic"', function () {
+      it('sets `x-queue-type` to "classic" and respects deprecated fields', () => {
+        options.type = 'classic';
+        options.queueLimit = 1000;
+        options.autoDelete = 100;
+        options.maxPriority = 100;
+        return ampqQueue(options, topology, serializers)
+          .then((instance) => {
+            return instance.define();
+          })
+          .then(() => {
+            amqpChannelMock.assertQueue.calledWith(
+              options.uniqueName,
+              {
+                queueLimit: options.queueLimit,
+                arguments: { 'x-queue-type': options.type }
+              });
+          });
+      });
+
+      it('Omits `x-dead-letter-strategy` argument if given', () => {
+        options.type = 'classic';
+        options.queueLimit = 1000;
+        options.maxPriority = 100;
+        options.deadLetterStrategy = 'at-least-once';
+        return ampqQueue(options, topology, serializers)
+          .then((instance) => {
+            return instance.define();
+          })
+          .then(() => {
+            amqpChannelMock.assertQueue.calledWith(
+              options.uniqueName,
+              {
+                ...options,
+                arguments: {
+                  'x-queue-type': options.type
+                }
+              });
+          });
+      });
+    });
+
     describe('when options.type is "quorum"', function () {
       it('sets `x-queue-type` to "quorum" and omits incompatible fields', () => {
         options.type = 'quorum';
         options.queueLimit = 1000;
+        options.autoDelete = true;
         options.maxPriority = 100;
         return ampqQueue(options, topology, serializers)
           .then((instance) => {
@@ -92,8 +135,9 @@ describe('AMQP Queue', function () {
       it('sets `x-dead-letter-strategy` argument if given', () => {
         options.type = 'quorum';
         options.queueLimit = 1000;
+        options.autoDelete = true;
         options.maxPriority = 100;
-        options.deadLetterStrategy = 100;
+        options.deadLetterStrategy = 'at-least-once';
         return ampqQueue(options, topology, serializers)
           .then((instance) => {
             return instance.define();

--- a/spec/behavior/queue.spec.js
+++ b/spec/behavior/queue.spec.js
@@ -110,6 +110,28 @@ describe('AMQP Queue', function () {
               });
           });
       });
+
+      it('Sets `x-queue-version` argument if given', () => {
+        options.type = 'classic';
+        options.queueLimit = 1000;
+        options.queueVersion = 2;
+        options.maxPriority = 100;
+        return ampqQueue(options, topology, serializers)
+          .then((instance) => {
+            return instance.define();
+          })
+          .then(() => {
+            amqpChannelMock.assertQueue.calledWith(
+              options.uniqueName,
+              {
+                ...options,
+                arguments: {
+                  'x-queue-type': options.type,
+                  'x-queue-version': options.queueVersion
+                }
+              });
+          });
+      });
     });
 
     describe('when options.type is "quorum"', function () {
@@ -150,6 +172,27 @@ describe('AMQP Queue', function () {
                 arguments: {
                   'x-queue-type': options.type,
                   'x-dead-letter-strategy': options.deadLetterStrategy
+                }
+              });
+          });
+      });
+
+      it('Omits `x-queue-version` argument if given', () => {
+        options.type = 'classic';
+        options.queueLimit = 1000;
+        options.queueVersion = 2;
+        options.maxPriority = 100;
+        return ampqQueue(options, topology, serializers)
+          .then((instance) => {
+            return instance.define();
+          })
+          .then(() => {
+            amqpChannelMock.assertQueue.calledWith(
+              options.uniqueName,
+              {
+                ...options,
+                arguments: {
+                  'x-queue-type': options.type
                 }
               });
           });

--- a/spec/behavior/queue.spec.js
+++ b/spec/behavior/queue.spec.js
@@ -53,11 +53,27 @@ describe('AMQP Queue', function () {
       });
     });
 
+    describe('when options.type is not set', function () {
+      it('sets `x-queue-type` to "classic"', () => {
+        const qType = 'classic';
+        options.queueLimit = 1000;
+        options.maxPriority = 100;
+        return ampqQueue(options, topology, serializers)
+          .then((instance) => {
+            return instance.define();
+          })
+          .then(() => {
+            amqpChannelMock.assertQueue.calledWith(
+              options.uniqueName,
+              { ...options, arguments: { 'x-queue-type': qType } });
+          });
+      });
+    });
+
     describe('when options.type is "quorum"', function () {
       it('sets `x-queue-type` to "quorum" and omits incompatible fields', () => {
         options.type = 'quorum';
         options.queueLimit = 1000;
-        options.autoDelete = true;
         options.maxPriority = 100;
         return ampqQueue(options, topology, serializers)
           .then((instance) => {

--- a/spec/behavior/queue.spec.js
+++ b/spec/behavior/queue.spec.js
@@ -82,7 +82,32 @@ describe('AMQP Queue', function () {
           .then(() => {
             amqpChannelMock.assertQueue.calledWith(
               options.uniqueName,
-              { queueLimit: options.queueLimit, arguments: { 'x-queue-type': options.type } });
+              {
+                queueLimit: options.queueLimit,
+                arguments: { 'x-queue-type': options.type }
+              });
+          });
+      });
+
+      it('sets `x-dead-letter-strategy` argument if given', () => {
+        options.type = 'quorum';
+        options.queueLimit = 1000;
+        options.maxPriority = 100;
+        options.deadLetterStrategy = 100;
+        return ampqQueue(options, topology, serializers)
+          .then((instance) => {
+            return instance.define();
+          })
+          .then(() => {
+            amqpChannelMock.assertQueue.calledWith(
+              options.uniqueName,
+              {
+                queueLimit: options.queueLimit,
+                arguments: {
+                  'x-queue-type': options.type,
+                  'x-dead-letter-strategy': options.deadLetterStrategy
+                }
+              });
           });
       });
     });

--- a/spec/integration/configuration.js
+++ b/spec/integration/configuration.js
@@ -1,5 +1,6 @@
 module.exports = {
   connection: {
+    protocol: 'amqp',
     name: 'default',
     user: 'guest',
     pass: 'guest',

--- a/spec/integration/typeSpecific.spec.js
+++ b/spec/integration/typeSpecific.spec.js
@@ -32,7 +32,7 @@ describe('Type Handling On Any Queue', function () {
           autoDelete: true,
           subscribe: true,
           deadletter: 'rabbot-ex.deadletter',
-          type: 'quorum'
+          type: 'classic'
         }
       ],
       bindings: [

--- a/spec/integration/typeSpecific.spec.js
+++ b/spec/integration/typeSpecific.spec.js
@@ -24,13 +24,15 @@ describe('Type Handling On Any Queue', function () {
           name: 'rabbot-q.topic-1',
           autoDelete: true,
           subscribe: true,
-          deadletter: 'rabbot-ex.deadletter'
+          deadletter: 'rabbot-ex.deadletter',
+          type: 'classic'
         },
         {
           name: 'rabbot-q.topic-2',
           autoDelete: true,
           subscribe: true,
-          deadletter: 'rabbot-ex.deadletter'
+          deadletter: 'rabbot-ex.deadletter',
+          type: 'quorum'
         }
       ],
       bindings: [

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -149,6 +149,7 @@ const Adapter = function (parameters) {
 
 Adapter.prototype.connect = function () {
   return new Promise(function (resolve, reject) {
+    const unreachable = 'No endpoints could be reached';
     const attempted = [];
     const attempt = function () {
       const [nextUri, serverHostname] = this.getNextUri();
@@ -166,7 +167,7 @@ Adapter.prototype.connect = function () {
           attempt(err);
         } else {
           log.info('Cannot connect to `%s` - all endpoints failed', this.name);
-          reject('No endpoints could be reached');
+          reject(unreachable);
         }
       }
       if (attempted.indexOf(nextUri) < 0) {
@@ -174,7 +175,7 @@ Adapter.prototype.connect = function () {
           .then(onConnection.bind(this), onConnectionError.bind(this));
       } else {
         log.info('Cannot connect to `%s` - all endpoints failed', this.name);
-        reject('No endpoints could be reached');
+        reject(unreachable);
       }
     }.bind(this);
     attempt();

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -116,7 +116,7 @@ const Adapter = function (parameters) {
   const pfxPath = getOption(parameters, 'RABBIT_PFX') || getOption(parameters, 'pfxPath');
   const useSSL = certPath || keyPath || passphrase || caPaths || pfxPath || parameters.useSSL;
   const portList = getOption(parameters, 'RABBIT_PORT') || getOption(parameters, 'port', (useSSL ? 5671 : 5672));
-  this.protocol = getOption(parameters, 'RABBIT_PROTOCOL') || (useSSL ? 'amqps' : 'amqp');
+  this.protocol = getOption(parameters, 'RABBIT_PROTOCOL') || getOption(parameters, 'protocol', undefined)?.replace(/:\/\/$/, '') || (useSSL ? 'amqps' : 'amqp');
   this.ports = split(portList);
   this.options = { noDelay: true };
 

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -61,8 +61,8 @@ function parseUri (uri) {
     const heartbeat = parsed.searchParams.get('heartbeat');
     return {
       useSSL: parsed.protocol.startsWith('amqps'),
-      user: parsed.username,
-      pass: parsed.password,
+      user: decodeURIComponent(parsed.username),
+      pass: decodeURIComponent(parsed.password),
       host: parsed.hostname,
       port: parsed.port,
       vhost: parsed.pathname ? parsed.pathname.slice(1) : undefined,

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -60,7 +60,7 @@ function parseUri (uri) {
     const parsed = new url.URL(uri);
     const heartbeat = parsed.searchParams.get('heartbeat');
     return {
-      useSSL: parsed.protocol === 'amqps',
+      useSSL: parsed.protocol.startsWith('amqps'),
       user: parsed.username,
       pass: parsed.password,
       host: parsed.hostname,

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -39,11 +39,14 @@ function aliasOptions (options, aliases, ...omit) {
 }
 
 function argOptions (options) {
+  const queueType = options.type || 'classic';
   const args = {
-    'x-queue-type': options.type || 'classic'
+    'x-queue-type': queueType
   };
-  if (options.type === 'quorum' && options.deadLetterStrategy) {
+  if (queueType === 'quorum' && options.deadLetterStrategy) {
     args['x-dead-letter-strategy'] = options.deadLetterStrategy;
+  } else if (queueType === 'classic' && options.queueVersion) {
+    args['x-queue-version'] = options.queueVersion;
   }
   return args;
 }
@@ -52,7 +55,7 @@ function define (channel, options, subscriber, connectionName) {
   // Quorum queues dropped support for message prioritiy, exclusivity and non-durable queues
   // See: https://www.rabbitmq.com/docs/quorum-queues#feature-matrix
   const quorumIncompatible = ['exclusive', 'autoDelete', 'maxPriority'];
-  const optsFields = ['subscribe', 'limit', 'noBatch', 'unique', 'type'];
+  const optsFields = ['subscribe', 'limit', 'noBatch', 'unique', 'type', 'queueVersion'];
   const omition = options.type === 'quorum' ? [...optsFields, ...quorumIncompatible] : optsFields;
 
   const valid = aliasOptions(options, {

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -40,6 +40,7 @@ function aliasOptions (options, aliases, ...omit) {
 
 function define (channel, options, subscriber, connectionName) {
   const valid = aliasOptions(options, {
+    type: 'x-queue-type',
     queuelimit: 'maxLength',
     queueLimit: 'maxLength',
     deadletter: 'deadLetterExchange',

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -38,6 +38,16 @@ function aliasOptions (options, aliases, ...omit) {
   }, {});
 }
 
+function argOptions (options) {
+  const args = {
+    'x-queue-type': options.type || 'classic'
+  };
+  if (options.type === 'quorum' && options.deadLetterStrategy) {
+    args['x-dead-letter-strategy'] = options.deadLetterStrategy;
+  }
+  return args;
+}
+
 function define (channel, options, subscriber, connectionName) {
   // Quorum queues dropped support for message prioritiy, exclusivity and non-durable queues
   // See: https://www.rabbitmq.com/docs/quorum-queues#feature-matrix
@@ -52,7 +62,8 @@ function define (channel, options, subscriber, connectionName) {
     deadLetter: 'deadLetterExchange',
     deadLetterRoutingKey: 'deadLetterRoutingKey'
   }, ...omition);
-  valid.arguments = { 'x-queue-type': options.type || 'classic' };
+  valid.arguments = argOptions(options);
+
   topLog.info("Declaring queue '%s' on connection '%s' with the options: %s",
     options.uniqueName, connectionName, JSON.stringify(options));
 

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -39,16 +39,12 @@ function aliasOptions (options, aliases, ...omit) {
 }
 
 function define (channel, options, subscriber, connectionName) {
-  let omition = ['subscribe', 'limit', 'noBatch', 'unique', 'type'];
-  /**
-   * Quorum queues dropped support for message prioritiy, exclusivity and non-durable queues
-   *
-   * @see https://www.rabbitmq.com/docs/quorum-queues#feature-matrix
-   */
-  if (options.type === 'quorum') {
-    const incompatible = ['exclusive', 'autoDelete', 'maxPriority'];
-    omition = [...omition, ...incompatible];
-  }
+  // Quorum queues dropped support for message prioritiy, exclusivity and non-durable queues
+  // See: https://www.rabbitmq.com/docs/quorum-queues#feature-matrix
+  const quorumIncompatible = ['exclusive', 'autoDelete', 'maxPriority'];
+  const optsFields = ['subscribe', 'limit', 'noBatch', 'unique', 'type'];
+  const omition = options.type === 'quorum' ? [...optsFields, ...quorumIncompatible] : optsFields;
+
   const valid = aliasOptions(options, {
     queuelimit: 'maxLength',
     queueLimit: 'maxLength',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -232,6 +232,7 @@ declare namespace Broker {
     queueLimit?: number;
     deadLetter?: string;
     subscribe?: boolean;
+    autoDelete?: boolean;
     passive?: boolean;
     messageTtl?: number;
     type?: "classic" | "quorum";

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -198,7 +198,7 @@ declare namespace Broker {
     port?: number;
     server?: string | string[];
     vhost?: string;
-    protocol?: string;
+    protocol?: "amqp" | "amqps";
     user?: string;
     pass?: string;
     timeout?: number;
@@ -232,6 +232,9 @@ declare namespace Broker {
     queueLimit?: number;
     deadLetter?: string;
     subscribe?: boolean;
+    passive?: boolean;
+    messageTtl?: number;
+    type?: "classic" | "quorum";
   }
 
   export interface BindingOptions {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -230,6 +230,7 @@ declare namespace Broker {
     name: string;
     limit?: number;
     queueLimit?: number;
+    queueVersion?: 1 | 2;
     deadLetter?: string;
     deadLetterRoutingKey?: string;
     deadLetterStrategy?: "at-most-once" | "at-least-once";

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -231,11 +231,14 @@ declare namespace Broker {
     limit?: number;
     queueLimit?: number;
     deadLetter?: string;
+    deadLetterRoutingKey?: string;
+    deadLetterStrategy?: "at-most-once" | "at-least-once";
     subscribe?: boolean;
     autoDelete?: boolean;
     passive?: boolean;
     messageTtl?: number;
     type?: "classic" | "quorum";
+    overflow?: "drop-head" | "reject-publish";
   }
 
   export interface BindingOptions {


### PR DESCRIPTION
1. Fix issue #26 : The accepted `protocol` value is now `amqp` and `amqps` without `://`
2. Fix issue #55: Use `encodeURIComponent()` for both user and password and do not url encode entire string
3. Add `messageTTL` and `passive` to `QueueOption`definition: documentation states these are valid yet they are not present
4. Add `type` to `QueueOptions`: Sets argument `x-queue-type`, as to [enable quorum support](https://www.rabbitmq.com/docs/quorum-queues)
5. Adjusted specs: added `protocol` in `connection` config (`spec/integration/configuration.js`) and queue type