### PR TITLE
feat: add `frameMax` connection option

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -25,6 +25,7 @@ Options is a hash that can contain the following:
 | **pass** | the password for the specified user. | `"guest"` |
 | **timeout** | how long to wait for a connection to be established in milliseconds. | `2000` |
 | **heartbeat** | how often the client and server check to see if they can still reacheach other, specified in seconds. | `30` |
+| **frameMax** | the size in bytes of the maximum frame allowed over the connection. | `4096` |
 | **replyQueue** | the name of the reply queue to use. | unique to the process |
 | **publishTimeout** | the default timeout in milliseconds for a publish call. | |
 | **replyTimeout** | the default timeout in milliseconds to wait for a reply. | |

--- a/spec/integration/connection.spec.js
+++ b/spec/integration/connection.spec.js
@@ -14,7 +14,7 @@ describe('Connection', function () {
     });
 
     it('should assign uri to connection', function () {
-      connected.uri.should.equal('amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=30');
+      connected.uri.should.equal('amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=30&frameMax=4096');
     });
 
     after(function () {
@@ -29,11 +29,11 @@ describe('Connection', function () {
         connected = c;
         done();
       });
-      rabbit.addConnection({ name: 'connectionWithUri', uri: 'amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=11' });
+      rabbit.addConnection({ name: 'connectionWithUri', uri: 'amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=11&frameMax=8192' });
     });
 
     it('should assign uri to connection', function () {
-      connected.uri.should.equal('amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=11');
+      connected.uri.should.equal('amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=11&frameMax=8192');
     });
 
     after(function () {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -203,6 +203,7 @@ declare namespace Broker {
     pass?: string;
     timeout?: number;
     heartbeat?: number;
+    frameMax?: number;
     replyQueue?:
       | boolean
       | string


### PR DESCRIPTION
Add the `frameMax` connection tuning parameter as implemented in amqplib[1]. Default to 4k (4096) to match amqplib's default.

[1]: https://amqp-node.github.io/amqplib/channel_api.html#tuning-parameters